### PR TITLE
新規会員登録　編集

### DIFF
--- a/app/assets/stylesheets/sign.scss
+++ b/app/assets/stylesheets/sign.scss
@@ -6,7 +6,7 @@
   }
   .sign-main  {
     background-color: whitesmoke;
-    height: 100vh;
+    height: 1000px;
     width: 100vw;
     &__container {
       background-color: white;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,5 @@ class User < ApplicationRecord
     validates :email,   presence: true,
                         uniqueness: {case_sensitive: false},
                         format: {with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i}
-
-    VALID_PASSWORD_REGEX = /\A[a-z0-9]+\z/i
-    validates :password, presence: true, length: { minimum: 7 }, format: { with: VALID_PASSWORD_REGEX }
   end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -26,7 +26,7 @@
               %span.form-group__require 必須
               = f.password_field :password,{autocomplete: "new-password",placeholder: " 7文字以上の半角英数字",class:'form-group__input',id:"password"}
             .form-group
-              = f.label :パスワード 
+              = f.label :パスワード確認用 
               %span.form-group__require 必須
               = f.password_field :password_confirmation,{autocomplete: "new-password",placeholder: " 7文字以上の半角英数字",class:'form-group__input',id:"password"}
             .form-group

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..15
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
参考1（最初5文字の時のエラー文、次に7文字以上のパスワードを打った時）
　https://gyazo.com/b5cf69135840da0ba06f613e105be23e

参考2（パスワード, パスワード確認用の名記入・1ページ目のview崩れ）
<img width="1680" alt="view1 新規会員登録" src="https://user-images.githubusercontent.com/65494059/91633183-3e675080-ea21-11ea-9b0a-60f45c04e7ca.png">

### What
・新規会員登録のパスワードを7文字以上15文字以下に設定
・パスワード, パスワード確認用の名記入
・新規会員登録の1ページ目のview崩れ

### Why
ユーザーが表示を見やすくするため