### PR TITLE
商品出品（売却）一覧作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,8 @@
 @import "modules/new";
 @import "modules/show";
 @import "modules/confirm";
+@import "modules/confirm_edit";
 @import "modules/users/mypage";
+@import "modules/users/display_lists";
 @import "modules/users/user-edit";
 @import "modules/credit_cards_new";

--- a/app/assets/stylesheets/modules/_confirm.scss
+++ b/app/assets/stylesheets/modules/_confirm.scss
@@ -80,7 +80,7 @@
       justify-content: center;
       border-top: 1px solid #999999;
       border-bottom: 1px solid #999999;
-      .buy-btn {
+      .buy-btn, .deletion-btn {
         background: #3CCACE;
         border: 1px solid #3CCACE;
         height: 50px;

--- a/app/assets/stylesheets/modules/_confirm_edit.scss
+++ b/app/assets/stylesheets/modules/_confirm_edit.scss
@@ -1,0 +1,28 @@
+.done{
+  height: 90vh;
+  padding: 100px;
+  &__title {
+    font-size: 22px;
+    text-align: center;
+    font-weight: bold;
+    margin: 0 auto;
+  }
+  &__link{
+    width: 250px;
+    height: 50px;
+    background-color: #3ccace;
+    display: block;
+    margin: 15px auto;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: center;
+
+    .link {
+      text-decoration: none;
+      color: #ffffff;
+      font-size: 18px;
+      line-height: 50px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/users/display_lists.scss
+++ b/app/assets/stylesheets/modules/users/display_lists.scss
@@ -1,0 +1,138 @@
+.item__body {
+  width: 100%;
+  height: 100%;
+  padding-bottom: 100px;
+  overflow: scroll;
+  &__title {
+    padding-top: 30px;
+    color: #3ccace;
+    font-size: 24px;
+    text-align: center;
+    font-weight: bold;
+  }
+
+  &__lists {
+    width: 100%;
+    margin: 33px auto;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-left: 130px;
+
+    &__list{
+      width: 220px;
+      height: 230px;
+      display: inline-block;
+      
+      position: relative;
+      margin-top: 20px;
+      margin-right: 20px;
+      
+      a{
+        background-color: #fff;
+        display: inline-block;
+        text-decoration: none;
+        position: relative;
+
+        figure{
+          width: 220px;
+          height: 150px;
+          position: relative;
+          overflow: hidden;
+          margin: 0;
+          z-index: auto;
+
+          img{
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            width: 100%;
+            z-index: auto;
+            height: 150px;
+            object-fit: cover;
+          }
+        }
+      }
+      .list__body{
+        color:#333;
+        padding: 7px;
+        height: 90px;
+        width: 220px;
+        
+        h3{
+          overflow: hidden;
+          line-height: 1.5;
+          font-size: 16px;
+          text-align: left;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          color: black;
+        }
+        &--wrapper{
+          display: flex;
+          .list__price{
+            font-size: 13px;
+            color: #333333;
+            width: 62px;
+            ul{
+              justify-content: space-between;
+              list-style: none;
+              font-size: 15px;
+              li{
+                color: #333333;
+              }
+            }
+            p{
+              font-size: 12px;
+              text-align: left;
+              color: #333333;
+              font-weight: normal;
+            }
+          }
+          .list-btn{
+            margin-left: 100px;
+            display: inline-block;
+            &__edit {
+              width: 50px;
+              color: #3ccace;
+              font-size: 14px;
+              font-weight: bold;
+              padding-left: 10px;
+              
+            }
+            &__delete{
+              width: 50px;
+              color: red;
+              font-size: 14px;
+              font-weight: bold;
+              margin-left: 10px;
+            }
+          }
+        }
+        
+      }
+      .list__sold{
+        width: 0;
+        height: 0;
+        border-top: 40px solid red;
+        border-right: 40px solid transparent;
+        border-bottom: 40px solid transparent;
+        border-left: 40px solid red;
+        z-index:100;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        &__inner{
+          color: #fff;
+          transform: rotate(-45deg);
+          font-size: 20px;
+          margin:-16px 0px 0px -32px;
+          letter-spacing: 2px;
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,28 @@
 class UsersController < ApplicationController
+  before_action :move_to_root, except: [:show, :destroy]
+
   def index
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def sold_lists
+  end
+  def display_lists
+  end
+
+  def confirm_deletion
+  end
+
+  def confirm_edit
+  end
+
+  private
+  def move_to_root  #ログインしていなければ、トップ画面に遷移
+    redirect_to root_path unless user_signed_in?
   end
 end

--- a/app/views/users/confirm_deletion.html.haml
+++ b/app/views/users/confirm_deletion.html.haml
@@ -1,0 +1,75 @@
+= render 'items/header'
+
+%nav.bread-crumbs
+  %ul
+    - breadcrumb :confirm_deletion
+    = breadcrumbs separator: " &rsaquo; "
+
+.confirm-main
+  .confirm-main__container
+    .confirm-main__container--header
+      %h2.confirm-tytle
+        削除内容の確認
+      %p.confirm-text
+        下記の商品内容でよろしければ、削除するを押してください。
+    .confirm-main__container--product-image
+      = image_tag "img01.png", class: 'img'
+
+    .confirm-main__container--property-box
+      .item-property
+        .item-property__column1
+          出品者
+        .item-property__column2
+          hoge
+      .item-property
+        .item-property__column1
+          カテゴリー
+        .item-property__column2
+          メンズ
+      .item-property
+        .item-property__column1
+          ブランド
+        .item-property__column2
+          不明
+      .item-property
+        .item-property__column1
+          商品サイズ
+        .item-property__column2
+          不明
+      .item-property
+        .item-property__column1
+          商品の状態
+        .item-property__column2
+          未使用に近い
+      .item-property
+        .item-property__column1
+          配送料の負担
+        .item-property__column2
+          送料込み(出品者の負担)
+      .item-property
+        .item-property__column1
+          発送元の地域
+        .item-property__column2
+          岩手県
+      .item-property
+        .item-property__column1
+          発送日の目安
+        .item-property__column2
+          4-7日で発送
+
+    .confirm-main__container--purchase-box
+      .confirm-subtotal
+        小計
+      .confirm-price
+        %div
+          ￥
+        %div
+          30000
+        %div
+          (税込)
+
+    = form_with url: confirm_edit_users_path, class: "confirm-main__container--buy-box" do |f|
+      = f.submit '削除する', class:"deletion-btn"
+
+
+= render 'items/footer'

--- a/app/views/users/confirm_edit.html.haml
+++ b/app/views/users/confirm_edit.html.haml
@@ -1,0 +1,10 @@
+= render 'items/header'
+
+.done
+  .done__title
+    商品を削除しました
+  .done__link
+    = link_to 'トップページへ戻る', root_path, class: 'link'
+
+= render 'items/footer'
+= render 'items/sell-btn'

--- a/app/views/users/display_lists.html.haml
+++ b/app/views/users/display_lists.html.haml
@@ -1,0 +1,150 @@
+= render 'items/header'
+%nav.bread-crumbs
+  %ul
+    - breadcrumb :user_display_lists
+    = breadcrumbs separator: " &rsaquo; "
+.item__body
+  .item__body__title
+    商品出品一覧
+  .item__body__lists
+    .item__body__lists__list
+      = link_to items_path do
+        %figure.list__img
+          = image_tag "img01.png"
+        .list__body
+          %h3.name
+            この料理は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  1000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to confirm_deletion_users_path , class: "list-btn__delete" do
+                削除
+
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img03.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  2000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+    
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img02.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  3000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img02.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  4000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+    
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img01.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  5000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img03.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  6000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag = image_tag "img02.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  3000円
+              %p  (税込)
+            .list-btn
+              = link_to "#" , class: "list-btn__edit" do
+                編集
+
+              = link_to "#", class: "list-btn__delete" do
+                削除
+
+= render 'items/footer'
+= render 'items/sell-btn'

--- a/app/views/users/mypage/_mypage-side.html.haml
+++ b/app/views/users/mypage/_mypage-side.html.haml
@@ -29,6 +29,22 @@
                 = icon('fas','angle-right')
       %li.user-navi__menu__list
         .user-navi__menu__list__item
+          = link_to display_lists_users_path, class: "list-table" do
+            .list-table__branch
+              %span.list-table__branch__name
+                商品出品一覧
+              .list-table__branch__icon
+                = icon('fas','angle-right')
+      %li.user-navi__menu__list
+        .user-navi__menu__list__item
+          = link_to sold_lists_users_path, class: "list-table" do
+            .list-table__branch
+              %span.list-table__branch__name
+                商品売却一覧
+              .list-table__branch__icon
+                = icon('fas','angle-right')
+      %li.user-navi__menu__list
+        .user-navi__menu__list__item
           = link_to "#", class: "list-table" do
             .list-table__branch
               %span.list-table__branch__name

--- a/app/views/users/sold_lists.html.haml
+++ b/app/views/users/sold_lists.html.haml
@@ -1,0 +1,60 @@
+= render 'items/header'
+%nav.bread-crumbs
+  %ul
+    - breadcrumb :user_sold_lists
+    = breadcrumbs separator: " &rsaquo; "
+
+.item__body
+  .item__body__title
+    商品売却一覧
+  .item__body__lists
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag "img01.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__price
+            %ul
+              %li
+                1000円
+            %p  (税込)
+          .list__sold
+            .list__sold__inner
+              sold
+
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag "img02.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__price
+            %ul
+              %li
+                2000円
+            %p  (税込)
+          .list__sold
+            .list__sold__inner
+              sold
+
+    .item__body__lists__list
+      = link_to "#" do
+        %figure.list__img
+          = image_tag "img03.png"
+        .list__body
+          %h3.name
+            この鍋は…
+          .list__price
+            %ul
+              %li
+                3000円
+            %p  (税込)
+          .list__sold
+            .list__sold__inner
+              sold
+
+= render 'items/footer'
+= render 'items/sell-btn'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -31,7 +31,23 @@ crumb :mypage do
   link "マイページ", users_path
 end
 
+# 商品出品一覧
+crumb :user_display_lists do
+  link "商品出品一覧", display_lists_users_path
+  parent :mypage
+end
 
+# 商品売却一覧
+crumb :user_sold_lists do
+  link "商品売却一覧", sold_lists_users_path
+  parent :mypage
+end
+
+# 商品削除確認ページ
+crumb :confirm_deletion do
+  link "商品削除確認ページ", confirm_deletion_users_path
+  parent :mypage
+end
 
 # crumb :projects do
 #   link "Projects", projects_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,16 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :users, only: [:index, :edit, :show] do
+    collection do
+      get 'sold_lists'
+      get 'display_lists'
+      get 'confirm_deletion'
+      get 'confirm_edit'
+      post 'confirm_edit'
+    end
+  end
+
   resources :users, only: [:index, :edit]
   resources :credit_cards, only: [:new]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
マイページから商品出品（売却）一覧をクリックして詳細が観れる。商品出品一覧は、編集や削除ができるボタンを追加。削除内容の確認のviewも作成

config/breadcrumbs.rb
パンくずリストを追加