### PR TITLE
トップページview崩れ2

### DIFF
--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -1,8 +1,8 @@
 .main-contens {
   background-color: white;
-  overflow: scroll;
-
+  
   .visual {
+    background-color: gray;
     width: 100%;
     height: 560px;
     background-image: image-url("bg-mainVisual-pict_pc.jpg");
@@ -16,7 +16,6 @@
 
     &__content {
       max-width: 1280px;
-      line-height: 1.2;
       width: 100%;
       margin: 0 auto;
       padding: 35px 0 0 0;
@@ -25,6 +24,7 @@
         text-shadow: 0 0 5px rgba(0, 0, 0, 0.6);
         font-size: 60px;
         color: white;
+        line-height: 1.2;
       }
 
       &__text {
@@ -69,7 +69,7 @@
       text-align: center;
       display: flex;
       width: 100%;
-      max-width: 1050px;
+      max-width: 1020px;
       margin: 0 auto;
 
       .list {
@@ -213,15 +213,17 @@
           font-size: 17px;
           font-weight: 200;
           text-align: left;
+          margin: 0 0 40px;
         }
       }
     }
   }
 
   .pickupCategory {
+    background-color: #f8f8f8;
     padding: 80px 0 0;
-    background-color: white;
     height: 100%;
+    padding-bottom: 80px;
 
     .head {
       text-align: center;
@@ -246,10 +248,10 @@
       }
 
       .productLists {
-        width: 780px;
+        width: 900px;
         margin: 26px auto;
         display: flex;
-        justify-content: space-around;
+        overflow-x: scroll;
 
         .productList {
           width: 220px;
@@ -281,39 +283,40 @@
                 object-fit: cover;
               }
             }
-          }
+            .productList--body {
+              background-color: white;
+              color: black;
+              padding: 16px;
 
-          .productList--body {
-            background-color: white;
-            color: black;
-            padding: 16px;
-
-            .product--name {
-              overflow: hidden;
-              line-height: 1.5;
-              font-size: 16px;
-              text-align: left;
-            }
-
-            .details {
-              font-size: 16px;
-
-              ul {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-
-                i {
-                  display: inline-block;
-                  font-size: inherit;
-                  text-rendering: auto;
-                  -webkit-font-smoothing: antialiased;
-                }
+              .product--name {
+                overflow: hidden;
+                line-height: 1.5;
+                font-size: 16px;
+                text-align: left;
               }
 
-              p {
-                font-size: 10px;
-                text-align: left;
+              .details {
+                font-size: 16px;
+
+                ul {
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+  
+                  i {
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-style: normal;
+                    font-variant: normal;
+                    text-rendering: auto;
+                    line-height: 1;
+                  }
+                }
+
+                p {
+                  font-size: 10px;
+                  text-align: left;
+                }
               }
             }
           }
@@ -323,9 +326,10 @@
   }
 
   .pickupBrand {
-    background-color: white;
+    background-color: #f8f8f8;
     padding: 80px 0 0;
     height: 100%;
+    padding-bottom: 80px;
 
     .head {
       text-align: center;
@@ -350,10 +354,10 @@
       }
 
       .productLists {
-        width: 780px;
+        width: 900px;
         margin: 26px auto;
         display: flex;
-        justify-content: space-around;
+        overflow-x: scroll;
 
         .productList {
           width: 220px;
@@ -385,6 +389,7 @@
                 object-fit: cover;
               }
             }
+          
 
             .productList--body {
               background-color: white;

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -104,77 +104,93 @@
           = link_to "#" do
             %figure.productList--img
               =image_tag "https://d3pbyuzcd27kd.cloudfront.net/wp-content/uploads/sites/8/2019/05/23191708/Rain-Drop-from-Garden-Rose.jpg" , class: "image__category"
-          .productList--body
-            %h3.product--name
-              薔薇
-            .details
-              %ul
-                %li
-                  1000円
-                %li
-                  %i.fa.fa-star.likeIcon
-                    1
-              %p
-                (税込)
+            .productList--body
+              %h3.product--name
+                薔薇
+              .details
+                %ul
+                  %li
+                    1000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      1
+                %p
+                  (税込)
         .productList
           = link_to "#" do
             %figure.productList--img
               =image_tag "https://www.edogawa-kankyozaidan.jp/files/file/1505119769.jpg" , class: "image__category"
-          .productList--body
-            %h3.product--name
-              ひまわり
-            .details
-              %ul
-                %li
-                  2000円
-                %li
-                  %i.fa.fa-star.likeIcon
-                    2
-              %p
-                (税込)
+            .productList--body
+              %h3.product--name
+                ひまわり
+              .details
+                %ul
+                  %li
+                    2000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      2
+                %p
+                  (税込)
         .productList
           = link_to "#" do
             %figure.productList--img
               =image_tag "https://lovegreen.net/wp-content/uploads/2016/03/GettyImages-460339841-e1481252505595.jpg" , class: "image__category"
-          .productList--body
-            %h3.product--name
-              紫陽花
-            .details
-              %ul
-                %li
-                  3000円
-                %li
-                  %i.fa.fa-star.likeIcon
-                    3
-              %p
-                (税込)
+            .productList--body
+              %h3.product--name
+                紫陽花
+              .details
+                %ul
+                  %li
+                    3000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      3
+                %p
+                  (税込)
         .productList
           = link_to "#" do
             %figure.productList--img
               =image_tag "https://d3pbyuzcd27kd.cloudfront.net/wp-content/uploads/sites/8/2020/04/10123945/1583378119242_365903_photo.jpg" , class: "image__category"
-          .productList--body
-            %h3.product--name
-              たんぽぽ
-            .details
-              %ul
-                %li
-                  4000円
-                %li
-                  %i.fa.fa-star.likeIcon
-                    4
-              %p
-                (税込)
+            .productList--body
+              %h3.product--name
+                たんぽぽ
+              .details
+                %ul
+                  %li
+                    4000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      4
+                %p
+                  (税込)
+        .productList
+          = link_to "#" do
+            %figure.productList--img
+              =image_tag "https://d3pbyuzcd27kd.cloudfront.net/wp-content/uploads/sites/8/2019/05/23191708/Rain-Drop-from-Garden-Rose.jpg" , class: "image__category"
+            .productList--body
+              %h3.product--name
+                薔薇
+              .details
+                %ul
+                  %li
+                    50000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      5
+                %p
+                  (税込)
   %section.pickupBrand
     %h2.head
       ピックアップブランド
     .productBox
       .productHead
-        %a{:href => "#"}
+        = link_to "#" do
           %h3.title
             アーカイバ
       .productLists
         .productList
-          %a{:href => "#"}
+          = link_to "#" do
             %figure.productList--img
               =image_tag "https://image.rakuten.co.jp/x-sell/cabinet/newbag/1908/42445944.jpg" , class: "image__category"
             .productList--body
@@ -190,7 +206,7 @@
                 %p
                   (税込)
         .productList
-          %a{:href => "#"}
+          = link_to "#" do
             %figure.productList--img
               =image_tag "https://image.rakuten.co.jp/x-sell/cabinet/newbag/1908/42445944.jpg" , class: "image__category"
             .productList--body
@@ -206,7 +222,7 @@
                 %p
                   (税込)
         .productList
-          %a{:href => "#"}
+          = link_to "#" do
             %figure.productList--img
               =image_tag "https://image.rakuten.co.jp/x-sell/cabinet/newbag/1908/42445944.jpg" , class: "image__category"
             .productList--body
@@ -222,7 +238,7 @@
                 %p
                   (税込)
         .productList
-          %a{:href => "#"}
+          = link_to "#" do
             %figure.productList--img
               =image_tag "https://image.rakuten.co.jp/x-sell/cabinet/newbag/1908/42445944.jpg" , class: "image__category"
             .productList--body
@@ -235,6 +251,22 @@
                   %li
                     %i.fa.fa-star.likeIcon
                       4
+                %p
+                  (税込)
+        .productList
+          = link_to "#" do
+            %figure.productList--img
+              =image_tag "https://d3pbyuzcd27kd.cloudfront.net/wp-content/uploads/sites/8/2019/05/23191708/Rain-Drop-from-Garden-Rose.jpg" , class: "image__category"
+            .productList--body
+              %h3.product--name
+                薔薇
+              .details
+                %ul
+                  %li
+                    65000円
+                  %li
+                    %i.fa.fa-star.likeIcon
+                      5
                 %p
                   (税込)
 %aside.appVisual3


### PR DESCRIPTION




### What
直した箇所
・ピックアップカテゴリー、ピックアップブランドの背景色などの設定。
・overflow-x: scroll;　を使って、写真のはみ出した部分をスクロールバーを用いて設定。
・右端の幅が足りなかったので付け加え。

### Why
ログイン時もログインしてない時もユーザーにわかりやすくするため。