### PR TITLE
商品詳細表示

### DIFF
--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -287,7 +287,7 @@
                   border-right: 40px solid transparent;
                   border-bottom: 40px solid transparent;
                   border-left: 40px solid red;
-                  z-index:100;
+                  z-index:1;
                   position: absolute;
                   top: 0px;
                   left: 0px;
@@ -414,7 +414,7 @@
                   border-right: 40px solid transparent;
                   border-bottom: 40px solid transparent;
                   border-left: 40px solid red;
-                  z-index:100;
+                  z-index:1;
                   position: absolute;
                   top: 0px;
                   left: 0px;

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -8,7 +8,7 @@
     width: 700px;
     &--product-box {
       background-color: white;
-      height: 1300px;
+      height: 1250px;
       padding: 20px 40px 0 40px;
       margin-bottom: 20px;
       .product-name {

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -22,7 +22,6 @@
         
         &__top {
           display: inline-block;
-          margin: 5px;
           position: relative;
           .img {
             height: 360px;
@@ -34,7 +33,7 @@
               border-right: 50px solid transparent;
               border-bottom: 50px solid transparent;
               border-left: 50px solid red;
-              z-index:100;
+              z-index:1;
               position: absolute;
               top: 0px;
               left: 0px;
@@ -53,13 +52,17 @@
           height: 90px;
           width: 560px;
           .bottom-image {
+            width: 100%;
             display: flex;
             justify-content: center;
             &__list{
               height: 100px;
-              object-fit: cover;
+              width: 24%;
+              margin-right: 1px;
               img{
                 height: 100px;
+                width: 133px;
+                object-fit: cover;
               }
             }
           }

--- a/app/assets/stylesheets/modules/users/display_lists.scss
+++ b/app/assets/stylesheets/modules/users/display_lists.scss
@@ -127,7 +127,7 @@
         border-right: 40px solid transparent;
         border-bottom: 40px solid transparent;
         border-left: 40px solid red;
-        z-index:100;
+        z-index:1;
         position: absolute;
         top: 0px;
         left: 0px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @user = @items.seller
+    @user = @item.seller
   end
 
   def confirm
@@ -16,8 +16,8 @@ class ItemsController < ApplicationController
 
   def new
     if user_signed_in?
-      @items = Item.new
-      @items.images.new
+      @item = Item.new
+      @item.images.new
     else
       redirect_to root_path, flash: {notice: "商品の出品にはログインする必要があります"}
     end
@@ -27,8 +27,8 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @items = Item.new(item_params)
-    if @items.save
+    @item = Item.new(item_params)
+    if @item.save
       redirect_to display_lists_user_path(current_user.id), flash: {notice: "商品の出品が完了しました"}
     else
       render :new
@@ -36,7 +36,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if @items.update(update_item_params)
+    if @item.update(update_item_params)
       redirect_to display_lists_user_path, flash: {notice: "商品情報の編集が完了しました"}
     else
       render :edit
@@ -45,8 +45,7 @@ class ItemsController < ApplicationController
 
   private
     def set_item
-      @items = Item.find(params[:id])
-      # @item = Item.find(params[:id])
+      @item = Item.find(params[:id])
     end
 
     def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @user = @items.seller
   end
 
   def confirm

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,6 +30,8 @@ class Item < ApplicationRecord
 
   belongs_to :category
   has_many :images
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
   
   accepts_nested_attributes_for :images, allow_destroy: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_one :address, dependent: :destroy
   has_one :profile, dependent: :destroy
+  has_many :items
 
   with_options presence: true do
     validates :nickname, presence: true, uniqueness: true

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,7 +1,7 @@
-= form_with(model: @items, local: true) do |f|
+= form_with(model: @item, local: true) do |f|
   .exhibit-main
     .exhibit-main__container
-      - if @items.id.present?
+      - if @item.id.present?
         .form-title
           商品情報編集ページ
       - else
@@ -20,7 +20,7 @@
             = f.fields_for :images do |image|
               %div{data:{index: "#{image.index}"},class: "js-file_group", id: "group_#{image.index}"}
                 %div{class: "image-previews", id: "image_preview_#{image.index}"}
-                  - if @items.id.present?
+                  - if @item.id.present?
                     = image_tag image.object.image.url, class: "image-preview"
                     = icon('fa', 'trash-alt', class: 'js-remove')
                 .file-field

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -102,7 +102,7 @@
       .productLists
         .productList
           - @items.each do |item| 
-            = link_to item_path(id: item.id), class: "productList__imgs" do
+            = link_to item_path(item), class: "productList__imgs" do
               .productList__wrapper
                 %figure.productList--img
                   = image_tag item.images.first.image.url
@@ -137,7 +137,7 @@
       .productLists
         .productList
           - @items_price.each do |item| 
-            = link_to item_path(id: item.id), class: "productList__imgs" do
+            = link_to item_path(item), class: "productList__imgs" do
               .productList__wrapper
                 %figure.productList--img
                   = image_tag item.images.first.image.url

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,49 +32,42 @@
             送料込み
       .item-detail
         %p
-          <商品の状態について>
-        %p
-          写真はイメージです。
+          = @items.detail
       .item-property
         .item-property__column1
           出品者
         .item-property__column2
-          hoge
-      .item-property
-        .item-property__column1
-          カテゴリー
-        .item-property__column2
-          メンズ
+          = @user.nickname
+      -# .item-property
+      -#   .item-property__column1
+      -#     カテゴリー
+      -#   .item-property__column2
+      -#     メンズ
       .item-property
         .item-property__column1
           ブランド
         .item-property__column2
-          不明
-      .item-property
-        .item-property__column1
-          商品サイズ
-        .item-property__column2
-          不明
+          = @items.brand
       .item-property
         .item-property__column1
           商品の状態
         .item-property__column2
-          未使用に近い
+          = @items.condition
       .item-property
         .item-property__column1
           配送料の負担
         .item-property__column2
-          送料込み(出品者の負担)
+          = @items.postage
       .item-property
         .item-property__column1
           発送元の地域
         .item-property__column2
-          岩手県
+          = @items.area
       .item-property
         .item-property__column1
           発送日の目安
         .item-property__column2
-          4-7日で発送
+          = @items.until_shipping
         
       .purchase
         - if @items.stock.to_i == 0
@@ -83,7 +76,7 @@
         
         - elsif user_signed_in?
           - if @items.seller_id == current_user.id
-            = link_to "商品の編集", "#", class: "purchase__edit"
+            = link_to "商品の編集", edit_item_path, class: "purchase__edit"
             = link_to "商品の削除", "#", class: "purchase__delete" 
           - else
             = link_to confirm_item_path , class: "purchase__buy-btn" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,22 +8,22 @@
   .detail-main__container
     .detail-main__container--product-box
       %h2.product-name
-        = @items.name
+        = @item.name
       %ul.product-image
         %li.product-image__top
-          = image_tag(@items.images.first.image.url, class: "img")
-          - if @items.stock.to_i == 0 
+          = image_tag(@item.images.first.image.url, class: "img")
+          - if @item.stock.to_i == 0 
             .img__sold
               .img__sold__inner
                 Sold
         %li.product-image__bottom
           %ul.bottom-image
-            - @items.images.each do |img|
+            - @item.images.each do |img|
               %li.bottom-image__list
                 = image_tag(img.image.url, class: "img")
       .price-box
         %p.price-box__item-price
-          = @items.price.to_s(:delimited)
+          = @item.price.to_s(:delimited)
           = "円"
         .price-box__item-fee
           %p.price-box__item-tax
@@ -32,7 +32,7 @@
             送料込み
       .item-detail
         %p
-          = @items.detail
+          = @item.detail
       .item-property
         .item-property__column1
           出品者
@@ -47,35 +47,35 @@
         .item-property__column1
           ブランド
         .item-property__column2
-          = @items.brand
+          = @item.brand
       .item-property
         .item-property__column1
           商品の状態
         .item-property__column2
-          = @items.condition
+          = @item.condition
       .item-property
         .item-property__column1
           配送料の負担
         .item-property__column2
-          = @items.postage
+          = @item.postage
       .item-property
         .item-property__column1
           発送元の地域
         .item-property__column2
-          = @items.area
+          = @item.area
       .item-property
         .item-property__column1
           発送日の目安
         .item-property__column2
-          = @items.until_shipping
+          = @item.until_shipping
         
       .purchase
-        - if @items.stock.to_i == 0
+        - if @item.stock.to_i == 0
           = link_to root_path, class: "purchase__sold" do
             売り切れました
         
         - elsif user_signed_in?
-          - if @items.seller_id == current_user.id
+          - if @item.seller_id == current_user.id
             = link_to "商品の編集", edit_item_path, class: "purchase__edit"
             = link_to "商品の削除", "#", class: "purchase__delete" 
           - else

--- a/app/views/users/display_lists.html.haml
+++ b/app/views/users/display_lists.html.haml
@@ -10,7 +10,7 @@
   .item__body__lists
     - @items.each do |item|
       .item__body__lists__list
-        = link_to item_path do
+        = link_to item_path(item) do
           %figure.list__img
             = image_tag item.images.first.image.url
           .list__body


### PR DESCRIPTION
### What

・ログアウト状態でも商品詳細ページを見ることができる
https://gyazo.com/01c92469da573d414d5a1245d012ba2b
・出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
https://gyazo.com/de5d48a0d2d684e799fecbd71c60b456
トップページから開いた場合
https://gyazo.com/789052b0b0112a32ade87d91c770c923
・出品者以外にしか商品購入のリンクが踏めないようになっている
https://gyazo.com/96c02ef9899478c098d2a2a4cdb36f3c
・ [こちらの見本](http://furima.tokyo/)と同じような形で、商品出品時に登録した情報が見られるようになっている

・出品者の名前や状態などが詳細に書かれている。
https://gyazo.com/efcb00253dd3086dfc3e6b8bd6efb4cb

### Why
出品者・購入者しか見れない画面を用いることで問題なく編集したり購入したりすることができる