### PR TITLE
出品商品一覧表示 追加実装

### DIFF
--- a/app/assets/stylesheets/modules/users/display_lists.scss
+++ b/app/assets/stylesheets/modules/users/display_lists.scss
@@ -43,15 +43,38 @@
           z-index: auto;
 
           img{
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
+            // position: absolute;
+            // top: 0;
+            // left: 0;
+            // right: 0;
+            // bottom: 0;
             width: 100%;
             z-index: auto;
             height: 150px;
             object-fit: cover;
+          }
+          .sold-label {
+            position: absolute;
+            z-index: 1;
+            top: 0;
+            left: 0;
+            width: 1px;
+            height: 1px;
+            border-top: 36px solid red;
+            border-right: 36px solid transparent;
+            border-bottom: 36px solid transparent;
+            border-left: 36px solid red;
+          }
+          .sold-label__inner {
+            position: absolute;
+            z-index: 1;
+            top: 12px;
+            left: 0;
+            color: #fff;
+            transform: rotate(-45deg);
+            font-size: 20px;
+            letter-spacing: 2px;
+            font-weight: bold;
           }
         }
       }

--- a/app/views/users/display_lists.html.haml
+++ b/app/views/users/display_lists.html.haml
@@ -13,6 +13,10 @@
         = link_to item_path(item) do
           %figure.list__img
             = image_tag item.images.first.image.url
+            - if item.stock.to_i == 0
+              .sold-label
+              .sold-label__inner
+                sold
           .list__body
             %p.name
               = item.name
@@ -26,11 +30,15 @@
                 %p
                   (税込)
               .list-btn
-                = link_to edit_item_path(item) , class: "list-btn__edit" do
-                  編集
-
-                = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
-                  削除
+                - if item.stock.to_i == 1
+                  = link_to edit_item_path(item) , class: "list-btn__edit" do
+                    編集
+                  = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
+                    削除
+                - else
+                  = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
+                    削除
+                
 
 = render 'items/footer'
 = render 'items/sell-btn'


### PR DESCRIPTION
# what
売却済商品において出品者が編集することを制限
売却済商品の一覧表示内での見た目変更

# why
ユーザーは一覧表示内で売却済商品の確認及び削除ができる