### PR TITLE
商品購入一覧（商品購入履歴）等

### DIFF
--- a/app/assets/stylesheets/modules/users/display_lists.scss
+++ b/app/assets/stylesheets/modules/users/display_lists.scss
@@ -1,8 +1,8 @@
 .item__body {
   width: 100%;
   height: 100%;
-  padding-bottom: 100px;
-  overflow: scroll;
+  padding-bottom: 50px;
+  overflow-y: scroll;
   &__title {
     padding-top: 30px;
     color: #3ccace;
@@ -166,6 +166,7 @@
   }
   .none_lists {
     text-align: center;
+    // margin: 30px 0 400px 0;
     margin-top: 30px;
     font-size: 20px;
   }

--- a/app/assets/stylesheets/modules/users/mypage.scss
+++ b/app/assets/stylesheets/modules/users/mypage.scss
@@ -2,7 +2,7 @@
   height: 100%;
   width: 1020px;
   margin: 40px auto 0;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 @import "modules/users/mypage-side";

--- a/app/assets/stylesheets/modules/users/user-edit.scss
+++ b/app/assets/stylesheets/modules/users/user-edit.scss
@@ -2,18 +2,17 @@
   height: 100%;
   width: 1020px;
   margin: 40px auto 0;
-  overflow: scroll;
   
   &__right {
     float: right;
     background-color: whitesmoke;
     width: 700px;
-    height: 200px;
+    height: 100%;
     position: relative;
 
     &__logout {
       position: absolute;
-      top: 50%;
+      top: 15%;
       left: 50%;
       transform: translateY(-50%) translateX(-50%);
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
   end
 
   def sold_lists
+    @items = Item.includes(:images).where(buyer_id: current_user.id).order('created_at DESC')
   end
 
   def display_lists

--- a/app/views/users/_lists.html.haml
+++ b/app/views/users/_lists.html.haml
@@ -1,0 +1,33 @@
+.item__body__lists
+  - @items.each do |item|
+    .item__body__lists__list
+      = link_to item_path(item) do
+        %figure.list__img
+          = image_tag item.images.first.image.url
+          - if current_user.id == item.seller_id
+            - if item.stock.to_i == 0
+              .sold-label
+              .sold-label__inner
+                sold
+        .list__body
+          %p.name
+            = item.name
+          .list__body--wrapper
+            .list__price
+              %ul
+                %li
+                  = item.price
+                %li.unit
+                  円
+              %p
+                (税込)
+            - if current_user.id == item.seller_id
+              .list-btn
+                - if item.stock.to_i == 1
+                  = link_to edit_item_path(item) , class: "list-btn__edit" do
+                    編集
+                  = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
+                    削除
+                - else
+                  = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
+                    削除

--- a/app/views/users/display_lists.html.haml
+++ b/app/views/users/display_lists.html.haml
@@ -7,38 +7,9 @@
 .item__body
   .item__body__title
     商品出品一覧
+  
   - if @items.present?  
-    .item__body__lists
-      - @items.each do |item|
-        .item__body__lists__list
-          = link_to item_path(item) do
-            %figure.list__img
-              = image_tag item.images.first.image.url
-              - if item.stock.to_i == 0
-                .sold-label
-                .sold-label__inner
-                  sold
-            .list__body
-              %p.name
-                = item.name
-              .list__body--wrapper
-                .list__price
-                  %ul
-                    %li
-                      = item.price
-                    %li.unit
-                      円
-                  %p
-                    (税込)
-                .list-btn
-                  - if item.stock.to_i == 1
-                    = link_to edit_item_path(item) , class: "list-btn__edit" do
-                      編集
-                    = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
-                      削除
-                  - else
-                    = link_to confirm_deletion_user_path(item) , class: "list-btn__delete" do
-                      削除
+    = render 'users/lists'
   - else
     .none_lists
       出品中の商品はありません

--- a/app/views/users/mypage/_mypage-side.html.haml
+++ b/app/views/users/mypage/_mypage-side.html.haml
@@ -13,10 +13,10 @@
                 = icon('fas','angle-right')
       %li.user-navi__menu__list
         .user-navi__menu__list__item
-          = link_to "#", class: "list-table" do
+          = link_to sold_lists_user_path(current_user), class: "list-table" do
             .list-table__branch
               %span.list-table__branch__name
-                商品購入一覧
+                商品購入履歴
               .list-table__branch__icon
                 = icon('fas','angle-right')
       %li.user-navi__menu__list
@@ -25,14 +25,6 @@
             .list-table__branch
               %span.list-table__branch__name
                 商品出品一覧
-              .list-table__branch__icon
-                = icon('fas','angle-right')
-      %li.user-navi__menu__list
-        .user-navi__menu__list__item
-          = link_to sold_lists_user_path(current_user), class: "list-table" do
-            .list-table__branch
-              %span.list-table__branch__name
-                商品売却一覧
               .list-table__branch__icon
                 = icon('fas','angle-right')
       %li.user-navi__menu__list

--- a/app/views/users/sold_lists.html.haml
+++ b/app/views/users/sold_lists.html.haml
@@ -6,55 +6,15 @@
 
 .item__body
   .item__body__title
-    商品売却一覧
-  .item__body__lists
-    .item__body__lists__list
-      = link_to "#" do
-        %figure.list__img
-          = image_tag "img01.png"
-        .list__body
-          %h3.name
-            この鍋は…
-          .list__price
-            %ul
-              %li
-                1000円
-            %p  (税込)
-          .list__sold
-            .list__sold__inner
-              sold
+    商品購入履歴
+  
+  - if @items.present?  
+    = render 'users/lists'
+  - else
+    .none_lists
+      購入済みの商品はありません
+                
 
-    .item__body__lists__list
-      = link_to "#" do
-        %figure.list__img
-          = image_tag "img02.png"
-        .list__body
-          %h3.name
-            この鍋は…
-          .list__price
-            %ul
-              %li
-                2000円
-            %p  (税込)
-          .list__sold
-            .list__sold__inner
-              sold
-
-    .item__body__lists__list
-      = link_to "#" do
-        %figure.list__img
-          = image_tag "img03.png"
-        .list__body
-          %h3.name
-            この鍋は…
-          .list__price
-            %ul
-              %li
-                3000円
-            %p  (税込)
-          .list__sold
-            .list__sold__inner
-              sold
 
 = render 'items/footer'
 = render 'items/sell-btn'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -37,9 +37,9 @@ crumb :user_display_lists do
   parent :mypage
 end
 
-# 商品売却一覧
+# 商品購入履歴
 crumb :user_sold_lists do
-  link "商品売却一覧", sold_lists_user_path
+  link "商品購入履歴", sold_lists_user_path
   parent :mypage
 end
 


### PR DESCRIPTION
・売却一覧表示を商品購入履歴に変更（パンくずリスとも変更）、マイページのサイドも変更
・部分テンプレートをし、商品出品一覧と商品購入履歴を一緒にした。
・usersコントローラーにbuyer_idを追加
・overflow: scroll;のした部分がおかしかったため、overflow-y: scroll;で縦だけ修正